### PR TITLE
Fix open issues, add word count API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /vendor/
+/.idea/
+phpunit.xml

--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ require 'vendor/autoload.php';
  * // just needed if you don't use composer
  * require 'Unbabel.php';
  *
- * use Unbabel/Unbabel;
+ * use Unbabel\Unbabel;
+ * use Unbabel\HttpDriver\Guzzle\GuzzleHttpDriver;
+ * use Guzzle\Http\Client
  *
- * $unbabel = new Unbabel('username', 'apiKey', $sandbox = false);
+ * $httpDriver = new GuzzleHttpDriver(new Client());
+ * $unbabel = new Unbabel('username', 'apiKey', $sandbox = false, $httpDriver);
  *
- * // $resp is an instance of a guzzle response object http://docs.guzzlephp.org/en/latest/http-messages.html#responses
+ * // $resp is an instance of \Unbabel\HttpDriver\Response
  * $opts = array('callback_url' => 'http://my-awesome-app/unbabel_callback.php');
  * $resp = $unbabel->getTranslation($text, $target_language, $opts);
  * if ($resp->getStatusCode() == 201) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,11 @@
     bootstrap                   = "./tests/bootstrap.php"
     >
 
+    <php>
+        <env name="UNBABEL_USERNAME" value="*** YOUR API USERNAME HERE***" />
+        <env name="UNBABEL_KEY" value="*** YOUR API KEY HERE***" />
+    </php>
+
     <testsuites>
         <testsuite name="TestBundle Test Suite">
             <directory>./tests/Unbabel/Tests</directory>

--- a/src/Unbabel/HttpDriver/Guzzle/GuzzleHttpDriver.php
+++ b/src/Unbabel/HttpDriver/Guzzle/GuzzleHttpDriver.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Unbabel\HttpDriver\Guzzle;
+
+use Guzzle\Http\Client;
+use Unbabel\HttpDriver\HttpDriverInterface;
+
+class GuzzleHttpDriver implements HttpDriverInterface
+{
+
+    protected $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param string|null $uri
+     * @param array|null $headers
+     * @param array $options
+     * @return Response
+     */
+    public function get($uri = null, $headers = null, $options = array())
+    {
+        return new Response($this->client->get($uri, $headers, $options)->send());
+    }
+
+    /**
+     * @param string|null $uri
+     * @param array|null $headers
+     * @param string|null $postBody
+     * @param array $options
+     * @return Response
+     */
+    public function post($uri = null, $headers = null, $postBody = null, array $options = array())
+    {
+        return new Response($this->client->post($uri, $headers, $postBody, $options)->send());
+    }
+
+    /**
+     * @param string|null $uri
+     * @param array|null $headers
+     * @param string|null $body
+     * @param array $options
+     * @return Response
+     */
+    public function patch($uri = null, $headers = null, $body = null, array $options = array())
+    {
+        return new Response($this->client->patch($uri, $headers, $body, $options)->send());
+    }
+
+
+}

--- a/src/Unbabel/HttpDriver/Guzzle/Response.php
+++ b/src/Unbabel/HttpDriver/Guzzle/Response.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Unbabel\HttpDriver\Guzzle;
+
+class Response implements \Unbabel\HttpDriver\Response
+{
+
+    protected $guzzleResponse;
+
+    public function __construct(\Guzzle\Http\Message\Response $guzzleResponse) {
+        $this->guzzleResponse = $guzzleResponse;
+    }
+
+    /**
+     * return JSON-decoded response
+     * @return array
+     */
+    public function json()
+    {
+        return $this->guzzleResponse->json();
+    }
+
+    /**
+     * Return raw response
+     * @return string
+     */
+    public function raw()
+    {
+        return $this->guzzleResponse->getBody(true);
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->guzzleResponse->getStatusCode();
+    }
+
+
+}

--- a/src/Unbabel/HttpDriver/HttpDriverInterface.php
+++ b/src/Unbabel/HttpDriver/HttpDriverInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Unbabel\HttpDriver;
+
+interface HttpDriverInterface
+{
+    /**
+     * @param string|null $uri
+     * @param array|null $headers
+     * @param array $options
+     * @return Response
+     */
+    public function get($uri = null, $headers = null, $options = array());
+
+    /**
+     * @param string|null $uri
+     * @param array|null $headers
+     * @param string|null $postBody
+     * @param array $options
+     * @return Response
+     */
+    public function post($uri = null, $headers = null, $postBody = null, array $options = array());
+
+    /**
+     * @param string|null $uri
+     * @param array|null $headers
+     * @param string|null $body
+     * @param array $options
+     * @return Response
+     */
+    public function patch($uri = null, $headers = null, $body = null, array $options = array());
+}

--- a/src/Unbabel/HttpDriver/Response.php
+++ b/src/Unbabel/HttpDriver/Response.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Unbabel\HttpDriver;
+
+interface Response
+{
+    /**
+     * return JSON-decoded response
+     * @return array
+     */
+    public function json();
+
+    /**
+     * Return raw response
+     * @return string
+     */
+    public function raw();
+
+    /**
+     * @return int
+     */
+    public function getStatusCode();
+}

--- a/tests/Unbabel/Tests/Integration/UnbabelTest.php
+++ b/tests/Unbabel/Tests/Integration/UnbabelTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Unbabel\Tests\Integration;
+
+use Guzzle\Http\Client;
+use Unbabel\HttpDriver\Guzzle\GuzzleHttpDriver;
+use Unbabel\Unbabel;
+
+/**
+ * UnbabelTest, this class just holds unit tests of Unbabel PHP SDK, a suite of integration tests against the sandbox
+ * is also desirable.
+ */
+class UnbabelTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @var Unbabel */
+    protected $unbabel;
+
+    public function setUp() {
+        parent::setUp();
+        $client = new Client();
+        $httpDriver = new GuzzleHttpDriver($client);
+        $this->unbabel = new Unbabel($_ENV['UNBABEL_USERNAME'], $_ENV['UNBABEL_KEY'], $sandbox = true, $httpDriver);
+    }
+
+    public function testLanguagePair()
+    {
+        $res = $this->unbabel->getLanguagePairs();
+        $this->assertEquals($res->getStatusCode(), 200);
+    }
+
+    public function testGetTones()
+    {
+        $res = $this->unbabel->getTones();
+        $this->assertEquals($res->getStatusCode(), 200);
+    }
+
+    public function testGetTopics()
+    {
+        $res = $this->unbabel->getTopics();
+        $this->assertEquals($res->getStatusCode(), 200);
+    }
+
+    public function testSubmitBulkTranslation()
+    {
+        $bulk = array(
+            array('text' => 'In the era of Siri', 'target_language' => 'pt'),
+            array('text' => 'In the era of Siri', 'target_language' => 'es')
+        );
+        $res = $this->unbabel->submitBulkTranslation($bulk);
+        $this->assertEquals($res->getStatusCode(), 202);
+        $job = $res->json();
+        $jobids = array($job['objects'][0]['uid'], $job['objects'][1]['uid']);
+        $this->checkSubmissionProgress($jobids);
+    }
+
+    public function testSubmitTranslation()
+    {
+        $text = 'In the era of Siri';
+        $source_language = 'en';
+        $target_language = 'pt';
+        $res = $this->unbabel->submitTranslation($text, $target_language);
+        $json = $res->json();
+        $this->checkSubmissionProgress(array($json['uid']));
+    }
+
+    private function checkSubmissionProgress($jobids) {
+        //$res = $unbabel->getLanguagePairs();
+        sleep(30);
+        foreach($jobids as $jobid) {
+            //Sleep for 30 seconds and check to make sure the job is in progress
+            $res = $this->unbabel->getTranslation($jobid);
+            $this->assertEquals($res->getStatusCode(), 200);
+            $job = $res->json();
+            $this->assertEquals($job['status'], Unbabel::NEW_);
+        }
+        sleep(60);
+        foreach($jobids as $jobid) {
+            //Sleep for 60 more seconds to make sure the job is done
+            $res = $this->unbabel->getTranslation($jobid);
+            $job = $res->json();
+            $this->assertEquals($job['status'], Unbabel::READY);
+        }
+
+    }
+
+}

--- a/tests/Unbabel/Tests/Unit/HttpDriver/GuzzleHttpDriverTest.php
+++ b/tests/Unbabel/Tests/Unit/HttpDriver/GuzzleHttpDriverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Unbabel\Tests\Unit\HttpDriver;
+
+use Guzzle\Http\Client;
+use Guzzle\Http\Message\Request;
+use Guzzle\Http\Message\Response;
+use Unbabel\HttpDriver\Guzzle\GuzzleHttpDriver;
+
+class GuzzleHttpDriverTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @var Client|\PHPUnit_Framework_MockObject_MockObject */
+    protected $client;
+
+    /** @var GuzzleHttpDriver */
+    protected $httpDriver;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->client = $this->getMockBuilder('Guzzle\Http\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->httpDriver = new GuzzleHttpDriver($this->client);
+    }
+
+    public function testGet()
+    {
+        $statusCode = 200;
+        $url = '/translation/';
+        $headers = array('Authorization' => 'ApiKey none:none');
+
+        $this->client->expects($this->once())
+            ->method('get')
+            ->with($url, $headers, array('query' => array('status' => 'translating')))
+            ->willReturn(new MockRequest($statusCode, $headers, '{"objects": [{"uid": "aaaaaa"}]}'));
+
+        $response = $this->httpDriver->get($url, $headers, array('query' => array('status' => 'translating')));
+
+        $this->assertEquals(array('objects' => array(0 => array('uid' => 'aaaaaa'))), $response->json());
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testPost()
+    {
+        $statusCode = 201;
+        $url = '/translation/';
+        $headers = array('Authorization' => 'ApiKey none:none');
+        $post_data = json_encode(array(
+            'text' => 'Some kind of text',
+            'target_language' => 'ru'
+        ));
+
+        $this->client->expects($this->once())
+            ->method('post')
+            ->with($url, $headers, $post_data, array())
+            ->willReturn(new MockRequest($statusCode, $headers, '{"uid": "bbbbbb"}'));
+
+        $response = $this->httpDriver->post($url, $headers, $post_data);
+
+        $this->assertEquals(array('uid' => 'bbbbbb'), $response->json());
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+
+    public function testPatch()
+    {
+        $statusCode = 200;
+        $url = '/translation/';
+        $headers = array('Authorization' => 'ApiKey none:none');
+        $post_data = json_encode(array(
+            'objects' => array(
+                0 => array(
+                    'text' => 'Some kind of text',
+                    'target_language' => 'ru'
+                ),
+                1 => array(
+                    'text' => 'Some kind of other text',
+                    'target_language' => 'latin'
+                )
+            )
+
+        ));
+
+        $response_json = '{"objects": [{"uid": "vvvvvv"}, {"uid": "eeeeee"}]}';
+        $this->client->expects($this->once())
+            ->method('patch')
+            ->with($url, $headers, $post_data, array())
+            ->willReturn(new MockRequest($statusCode, $headers, $response_json));
+
+        $response = $this->httpDriver->patch($url, $headers, $post_data);
+
+        $this->assertEquals(json_decode($response_json, true), $response->json());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($response_json, $response->raw());
+    }
+}
+
+class MockRequest
+{
+    protected $response;
+
+    public function __construct($statusCode, $headers, $body)
+    {
+        $this->response = new Response($statusCode, $headers, $body);
+    }
+
+    public function send()
+    {
+        return $this->response;
+    }
+}

--- a/tests/Unbabel/Tests/Unit/UnbabelTest.php
+++ b/tests/Unbabel/Tests/Unit/UnbabelTest.php
@@ -2,79 +2,187 @@
 
 namespace Unbabel\Tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use Unbabel\HttpDriver\HttpDriverInterface;
 use Unbabel\Unbabel;
 
-/**
- * UnbabelTest, this class just holds unit tests of Unbabel PHP SDK, a suite of integration tests against the sandbox
- * is also desirable.
- */
-class UnbabelTest extends PHPUnit_Framework_TestCase
+class UnbabelTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function setUp() {
+    /** @var Unbabel */
+    protected $unbabel;
+
+    /** @var HttpDriverInterface|\PHPUnit_Framework_MockObject_MockObject */
+    protected $httpDriver;
+
+    protected function setUp()
+    {
         parent::setUp();
-        $this->unbabel = new Unbabel($GLOBALS['username'], $GLOBALS['apikey'], $sandbox = true);
+
+        $this->httpDriver = $this->getMock('Unbabel\HttpDriver\HttpDriverInterface');
+        $this->unbabel = new Unbabel($_ENV['UNBABEL_USERNAME'], $_ENV['UNBABEL_KEY'], true, $this->httpDriver);
     }
 
-    public function testLanguagePair()
+    public function testItShouldSubmitATranslation()
     {
-        $res = $this->unbabel->getLanguagePairs();
-        $this->assertEquals($res->getStatusCode(), 200);
+        $post_data = $this->getRequestObject('Unbabel test string', 'en', 'pl');
+
+        $this->httpDriver->expects($this->once())
+            ->method('post')
+            ->with($this->unbabel->buildRequestUrl('/translation/'), $this->unbabel->getHeaders(), json_encode($post_data));
+
+        $this->unbabel->submitTranslation('Unbabel test string', 'pl', array(
+            'source_language' => 'en',
+            'callback_url' => 'http://unbabel.com/',
+            'formality' => 'Informal',
+            'instructions' => 'Go out of you way to be kind to somebody today.',
+            'text_format' => 'text'
+        ));
     }
 
-    public function testGetTones()
+    public function testItShouldSubmitMultipleTranslations()
     {
-        $res = $this->unbabel->getTones();
-        $this->assertEquals($res->getStatusCode(), 200);
+        $post_data = array(
+            'objects' => array(
+                $this->getRequestObject('Unbabel test string 1', 'en', 'pl'),
+                $this->getRequestObject('Unbabel test string 2', 'en', 'zu'),
+                $this->getRequestObject('Unbabel test string 3', 'en', 'fr')
+            )
+        );
+
+        $this->httpDriver->expects($this->once())
+            ->method('patch')
+            ->with($this->unbabel->buildRequestUrl('/translation/'), $this->unbabel->getHeaders(), json_encode($post_data));
+
+        $this->unbabel->submitBulkTranslation(array(
+            array(
+                'text' => 'Unbabel test string 1',
+                'target_language' => 'pl',
+                'source_language' => 'en'
+            ),
+            array(
+                'text' => 'Unbabel test string 2',
+                'target_language' => 'zu',
+                'source_language' => 'en'
+            ),
+            array(
+                'text' => 'Unbabel test string 3',
+                'target_language' => 'fr',
+                'source_language' => 'en'
+            ),
+        ), array(
+            'callback_url' => 'http://unbabel.com/',
+            'formality' => 'Informal',
+            'instructions' => 'Go out of you way to be kind to somebody today.',
+            'text_format' => 'text'
+        ));
     }
 
-    public function testGetTopics()
+    public function testItShouldCheckTranslationStatusByUID()
     {
-        $res = $this->unbabel->getTopics();
-        $this->assertEquals($res->getStatusCode(), 200);
+        $uid = 'f94ec485db';
+
+        $this->httpDriver->expects($this->once())
+            ->method('get')
+            ->with($this->unbabel->buildRequestUrl('/translation/' . $uid . '/'), $this->unbabel->getHeaders(), array('query' => array()));
+
+        $this->unbabel->getTranslation($uid);
     }
 
-    public function testSubmitBulkTranslation()
+    public function testItShouldGetAllJobsWithASpecificStatus()
     {
-        $bulk = [
-            ['text' => 'In the era of Siri', 'target_language' => 'pt'],
-            ['text' => 'In the era of Siri', 'target_language' => 'es']
-        ];
-        $res = $this->unbabel->submitBulkTranslation($bulk);
-        $this->assertEquals($res->getStatusCode(), 202);
-        $job = $res->json();
-        $jobids = [$job['objects'][0]['uid'], $job['objects'][1]['uid']];
-        $this->checkSubmissionProgress($jobids);
+        $status = 'translating';
+
+        $this->httpDriver->expects($this->once())
+            ->method('get')
+            ->with($this->unbabel->buildRequestUrl('/translation/'), $this->unbabel->getHeaders(), array('query' => array('status' => $status)));
+
+        $this->unbabel->getJobsWithStatus($status);
     }
 
-    public function testSubmitTranslation()
+    public function testGetAllJobsShouldRejectUnknownStatuses()
     {
-        $text = 'In the era of Siri';
-        $source_language = 'en';
-        $target_language = 'pt';
-        $res = $this->unbabel->submitTranslation('In the era of Siri', 'pt');
-        $this->checkSubmissionProgress([$res->json()['uid']]);
+        $status = 'beep beep beep';
+
+        $this->httpDriver->expects($this->never())
+            ->method('get');
+
+        $this->setExpectedException('Unbabel\Exception\InvalidArgumentException');
+
+        $this->unbabel->getJobsWithStatus($status);
     }
 
-    private function checkSubmissionProgress($jobids) {
-        //$res = $unbabel->getLanguagePairs();
-        sleep(30);
-        foreach($jobids as $jobid) {
-            //Sleep for 30 seconds and check to make sure the job is in progress
-            $res = $this->unbabel->getTranslation($jobid);
-            $this->assertEquals($res->getStatusCode(), 200);
-            $job = $res->json();
-            $this->assertEquals($job['status'], Unbabel::NEW_);
-        }
-        sleep(60);
-        foreach($jobids as $jobid) {
-            //Sleep for 60 more seconds to make sure the job is done
-            $res = $this->unbabel->getTranslation($jobid);
-            $job = $res->json();
-            $this->assertEquals($job['status'], Unbabel::READY);
-        }
+    public function testItShouldGetLanguagePairs()
+    {
+        $this->httpDriver->expects($this->once())
+            ->method('get')
+            ->with($this->unbabel->buildRequestUrl('/language_pair/'), $this->unbabel->getHeaders(), array('query' => array()));
 
+        $this->unbabel->getLanguagePairs();
     }
 
+    public function testItShouldGetTones()
+    {
+        $this->httpDriver->expects($this->once())
+            ->method('get')
+            ->with($this->unbabel->buildRequestUrl('/tone/'), $this->unbabel->getHeaders(), array('query' => array()));
+
+        $this->unbabel->getTones();
+    }
+
+    public function testItShouldGetTopics()
+    {
+        $this->httpDriver->expects($this->once())
+            ->method('get')
+            ->with($this->unbabel->buildRequestUrl('/topic/'), $this->unbabel->getHeaders(), array('query' => array()));
+
+        $this->unbabel->getTopics();
+    }
+
+    public function testItShouldGetWordCount()
+    {
+        $text = 'beep beep, I am a robot.';
+
+        $this->httpDriver->expects($this->once())
+            ->method('post')
+            ->with($this->unbabel->buildRequestUrl('/wordcount/'), $this->unbabel->getHeaders(), json_encode(array('text' => $text)));
+
+        $this->unbabel->getWordCount($text);
+    }
+
+    public function testItShouldThrowAnExceptionForInvalidMethods()
+    {
+        $this->setExpectedException('Unbabel\Exception\InvalidArgumentException');
+
+        $unbabel = new BadUnbabel($_ENV['UNBABEL_USERNAME'], $_ENV['UNBABEL_KEY'], true, $this->httpDriver);
+
+        $unbabel->badRequestMethod();
+    }
+
+    /**
+     * @param string $text
+     * @param string $from
+     * @param string $to
+     * @return array
+     */
+    protected function getRequestObject($text, $from, $to)
+    {
+        $post_data = array(
+            'text' => $text,
+            'target_language' => $to,
+            'source_language' => $from,
+            'callback_url' => 'http://unbabel.com/',
+            'formality' => 'Informal',
+            'instructions' => 'Go out of you way to be kind to somebody today.',
+            'text_format' => 'text'
+        );
+        return $post_data;
+    }
+}
+
+class BadUnbabel extends Unbabel
+{
+    public function badRequestMethod()
+    {
+        $this->request('/', array(), 'options');
+    }
 }


### PR DESCRIPTION
Issue #3: Remove the need for run-test.sh.  The user should copy phpunit.xml.dist to phpunit.xml, change the values, and run the tests.
Issue #4: The current tests are actually integration tests.  Move them.
(Sidenote: testing translation submissions doesn't always pass.  Sometimes they change too quickly, sometimes too slowly)
Clean up the integration tests a little.
The composer.json says php >= 5.3.  Remove PHP 5.4 syntax in tests.
Add unit tests.
Fix an issue where the options weren't being overlaid onto each request.
Update available statuses as per https://github.com/Unbabel/unbabel_api
Add a new method to get the word count, as per http://developers.unbabel.com/docs/post-wordcount
Update the documentation.